### PR TITLE
Wording tweaks, punctuation fixes and markdown linted. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Author: Martin Jackson - [@actionjack](https://twitter.com/actionjack)
 
 [![Build Status](https://travis-ci.org/actionjack/so-you-want-to-onboard-a-devops-engineer.svg?branch=master)](https://travis-ci.org/actionjack/so-you-want-to-onboard-a-devops-engineer)
 
-At the moment everyone seems to be so concerned with recruiting DevOps Engineers but I feel the process of on-boarding them and giving them the environment to succeed is still a hit and miss affair, especially in busy organisations.
+At the moment everyone seems to be so concerned with recruiting DevOps practitioners but I feel the process of on-boarding them and giving them the environment to succeed is still a hit and miss affair, especially in busy organisations.
 
 Also nobody (at least nobody I know…) wants to work in a difficult environment:
 * Bad environments (and [broken cultures](https://julesx.com/toxic-work-culture-forcing-best-employees-quit/)) do not attract nor retain top talent. In fact it does the opposite.
@@ -18,7 +18,7 @@ Also nobody (at least nobody I know…) wants to work in a difficult environment
 > “Everything should be made as simple as possible, but no simpler.”
 >> Albert Einstein
 
-Reduce the time spent learning environments by building them to be easy to understand, with a focus on a making it possible for every engineer (new or old) to become effective in the shortest possible amount of time.
+Reduce the time spent learning environments by building them to be easy to understand, with a focus on a making it possible for every developer (new or old) to become effective in the shortest possible amount of time.
 
 Here is some guidance on how to make your environment easier to onboard and keep the people working on them happy.
 
@@ -55,11 +55,11 @@ Here is some guidance on how to make your environment easier to onboard and keep
   * [Technical Expertise in that specific problem domain](https://team-manual.cloud.service.gov.uk/team/orientation/#avoid-assuming-expertise)
   * The local Taxonomy - concepts and language does vary for work place to work place. e.g. pre-approved changes and standard changes many not necessarily mean the same thing from job to job.
 * What are the Preferred practices or ["Design Principles"](https://www.gov.uk/design-principles)?
-* Listen to their point of view. Bringing in a new person is a prime opportunity to find out where the code or process needs improvement
+* Listen to their point of view. Bringing in a new person is a prime opportunity to find out where the code or process needs improvement.
 * Test your mentoring and on boarding process to flush out any shortfalls by getting the last person who joined to mentor the new joiner.
 * Make your documentation inclusive e.g. this document is parsed using [alex](http://alexjs.com/) in order to catch insensitive and inconsiderate writing.
 * Be wary of not overloading new starts with too much information. There is often quite a lot to learn (even more than you think), instead provide a set of useful links so people can research at their own pace.
-* Write code that takes into account how future maintainers will feel reading it, let your code be [empathetic](https://www.benjaminjohnson.me/blog/empathetic-code/)
+* Write code that takes into account how future maintainers will feel reading it, let your code be [empathetic](https://www.benjaminjohnson.me/blog/empathetic-code/).
 
 
 ### Have up to date Documentation
@@ -79,7 +79,7 @@ It's important to either have or do the following:
 * An overview of the company’s infrastructure.
 * Systems integration points and their third party dependencies
 * A intranet/wiki or enterprise social network to Learn about different teams, key members with pictures. On day one, one can easily get overwhelmed with lots of new names and faces.
-* Have documentation for your alerts. If something is important enough to disturb the on-call person about, it's important enough to have a runbook entry about it. If you alert because _foo queue is too long_, there should be a [runbook](http://holyhandgrenade.org/blog/2011/08/runbooks-are-stupid-and-youre-doing-them-wrong/) entry describing how to fix it. 
+* Have documentation for your alerts. If something is important enough to disturb the on-call person about, it's important enough to have a runbook entry about it. If you alert because _foo queue is too long_, there should be a [runbook](http://holyhandgrenade.org/blog/2011/08/runbooks-are-stupid-and-youre-doing-them-wrong/) entry describing how to fix it.
   * At one client I worked with we actually managed to configure the monitoring system so the alerts themselves actually had a link to the relevant runbook entry :+1: :clap:
 * Create a Glossary of Terms [e.g. a Minipedia] for describing any organisation specific acronyms or terms
   * [Create an on-boarding wiki page (i.e. Confluence/Google Docs)](https://wiki.mozilla.org/Devops/onboarding)
@@ -135,7 +135,7 @@ It's important to either have or do the following:
     * [Gradle](https://gradle.org/)
     * [Rake](https://ruby.github.io/rake/)
     * [Fabric](http://www.fabfile.org/)
-  * If you use configuration management tools then use them repeatly and/or test them, try to avoid one shot configuration managment i.e. the operation is only run once once  to configure a resource even one you do not expect to change, because it will change and it will break and you will be rushing around trying to figure out what happened.
+  * If you use configuration management tools then use them repeatedly and/or test them, try to avoid one shot configuration management i.e. the operation is only run once once  to configure a resource even one you do not expect to change, because it will change and it will break and you will be rushing around trying to figure out what happened.
   * Put safe  conditionals in your configuration management to do be able to test runs without the worry of screwing up e.g. Ansible tasks:
   * Use the **Guard Rail Pattern** by putting safe  conditionals in your configuration management to do be able to test runs without the worry of screwing up e.g. Ansible tasks:
 
@@ -216,7 +216,7 @@ It's important to either have or do the following:
   * :+1: Have a Clear and concise [git history](http://www.annashipman.co.uk/jfdi/good-pull-requests.html) that [clearly](https://commitizen.github.io/cz-cli/) and easily documents the changes done and the reasons why in your repositories
 * Make [Pull Requests](https://help.github.com/articles/about-pull-requests/) a first class citizen, nothing is more demoralising than having a Pull Request sitting around without [feedback](https://devchecklists.com/pull-requests-checklist/) and a chance of being merged especially if it needs to be continually rebased.
 * Good [Pull Requests](https://github.com/alphagov/frontend/pull/784) can also be an excellent teaching tool for new starts or old hands alike, a good PR tell's you what was implemented, why and how, so if you (or anyone else) need to do something similar in the future it will make things a lot easier than relying on your memory or tribal knowledge. You can also prompt for good Pull Requests by using [Pull Request Templates](https://docs.gitlab.com/ee/user/project/description_templates.html) that suggest your best practice format.
-* If you use [slack](https://slack.com) or something similiar consider adding a notification bot for pull request and push activities, e.g. for [bitbucket](https://marketplace.atlassian.com/apps/1213042/slack-notifications-plugin?hosting=server&tab=overview) or [github](https://github.com/Talkdesk/pr-police) to notify your colleagues that a Pull Request is ready for review.
+* If you use [slack](https://slack.com) or something similar consider adding a notification bot for pull request and push activities, e.g. for [bitbucket](https://marketplace.atlassian.com/apps/1213042/slack-notifications-plugin?hosting=server&tab=overview) or [github](https://github.com/Talkdesk/pr-police) to notify your colleagues that a Pull Request is ready for review.
 * Keep your pull request list short and tidy, [merge good requests quickly](https://medium.com/@biratkirat/step-52-let-your-project-speak-for-itself-daniel-lindner-e45a0b1ce2c7) and close poor ones or those that are never going to be merged.
 * Integrate your git history with your external issue tracker so that it can automatically reference the changes related to a story and put in place some [automated branch naming pattern protection](https://help.github.com/en/articles/configuring-protected-branches) to ensure that any branches match the issue trackers issue reference format, this way you enforce the best practice of a branch matching a historical record in (for example) Jira as to why something was created, changed or deleted.
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,14 @@ Author: Martin Jackson - [@actionjack](https://twitter.com/actionjack)
 At the moment everyone seems to be so concerned with recruiting DevOps practitioners but I feel the process of on-boarding them and giving them the environment to succeed is still a hit and miss affair, especially in busy organisations.
 
 Also nobody (at least nobody I know…) wants to work in a difficult environment:
+
 * Bad environments (and [broken cultures](https://julesx.com/toxic-work-culture-forcing-best-employees-quit/)) do not attract nor retain top talent. In fact it does the opposite.
 
 > “Suffering increases in proportion to knowledge of a better way.”
 >> Jim Hickstein
 
 ## Making it easy to get work done from day one
+
 <summary>Simplify, simplify and after that simplify some more</summary>
 
 > “Everything should be made as simple as possible, but no simpler.”
@@ -23,6 +25,7 @@ Reduce the time spent learning environments by building them to be easy to under
 Here is some guidance on how to make your environment easier to onboard and keep the people working on them happy.
 
 ## Basics
+
 <summary>The raw basics</summary>
 
 > “The only way you can stay on top is to remember to touch bottom and get back to basics.”
@@ -34,10 +37,10 @@ Here is some guidance on how to make your environment easier to onboard and keep
 * Let people know if they are required to use their own equipment or are being supplied with specified equipment and what Operating System.
 * If you haven't already done so adopt some Group Chat software like [Slack](https://slack.com/), [Microsoft Teams](https://products.office.com/en-us/microsoft-teams/group-chat-software) or [Rocket Chat](https://rocket.chat/) this kind of software is beneficial to all and reduces pressure on key individuals because your questions go out to a group of people rather than target specific individuals who may be busy and under constant interruption.
   * If you do the above try and implement some [communications etiquette](https://hiverhq.com/blog/slack-etiquette/), for example when you answer someone create the answer in a thread so the questions, context, conversation and possibly solution are kept in the same place rather than being strewn throughout the chat history.
- * Provide a High-level Environment overview so new starts know what they are working on and what technologies they need to get up to speed on.
-
+  * Provide a High-level Environment overview so new starts know what they are working on and what technologies they need to get up to speed on.
 
 ### Culture
+
 <summary>Aim to create a culture of empathy and psychological safety </summary>
 
 > “It's possible for good people, in perversely designed systems, to casually perpetrate acts of great harm on strangers, sometimes without ever realising it.”
@@ -61,8 +64,8 @@ Here is some guidance on how to make your environment easier to onboard and keep
 * Be wary of not overloading new starts with too much information. There is often quite a lot to learn (even more than you think), instead provide a set of useful links so people can research at their own pace.
 * Write code that takes into account how future maintainers will feel reading it, let your code be [empathetic](https://www.benjaminjohnson.me/blog/empathetic-code/).
 
-
 ### Have up to date Documentation
+
 <summary>Make it easy to understand and do the things</summary>
 
 > “Stale documentation is not only misleading, it is positively harmful.”
@@ -88,28 +91,28 @@ It's important to either have or do the following:
 * Write your documentation as if it's going to be [open](https://www.gov.uk/design-principles#tenth) to public scrutiny someday.
 * Have an easy to use and setup collection of shared resources e.g. bookmark file of URL links, .ssh/config files
 * If possible keep your documentation as close to the code as possible (possibly as [Markdown](https://www.markdownguide.org/)) rather than referencing external resources like wikis or, use a [static site generator](https://www.markdownguide.org/getting-started#documentation) this way you are more likely to have up to date documentation, since you get immediate feedback when you do a review of code changes rather than having to separately review a PR and a Wiki Page. Some options are:
-  * [mkdocs](https://www.mkdocs.org/), 
+  * [mkdocs](https://www.mkdocs.org/),
   * [hugo](https://gohugo.io/),
-  * [sphinx](https://docs.readthedocs.io/en/stable/intro/getting-started-with-sphinx.html) or 
+  * [sphinx](https://docs.readthedocs.io/en/stable/intro/getting-started-with-sphinx.html) or
   * [Jekyll](https://jekyllrb.com/)
 * If there are problems that you have to work around in your code then in the comments link to some sort of permanent record (e.g. a URL of a Jira story or [ADR](https://github.com/joelparkerhenderson/architecture_decision_record)) for why, the following code comment caused me to do a lot of running around (The `git blame' gave me a commit that lead to a PR that had zero details in it, authored by someone who could not remember why they put that in the code.):
-```
-    instance_type: m4.4xlarge # Larger than this currently causes issues on our AMIs…
-```
+
+  ```yaml
+  instance_type: m4.4xlarge # Larger than this currently causes issues on our AMIs…
+  ```
+
 * what would have been more helpful would have been:
 
-```
-    instance_type: m4.4xlarge # Larger than this type causes issues see REF-2019
-```
-
-
+  ```yaml
+  instance_type: m4.4xlarge # Larger than this type causes issues see REF-2019
+  ```
 
 ### Operations
 
 <summary>Make it easy to get stuff done</summary>
 
 > [“Complexity exacts a staggering tax on your humans. Good Ops engineers attempt to pay down that tax.”](https://twitter.com/bridgetkromhout/status/647333814411358208)
-> >  [Charity Majors](https://twitter.com/mipsytipsy)
+>> [Charity Majors](https://twitter.com/mipsytipsy)
 
 * Have all relevant user accounts and access setup and ready
 * Create [Operations Checklists](http://atulgawande.com/book/the-checklist-manifesto/) for your key processes
@@ -139,13 +142,11 @@ It's important to either have or do the following:
   * Put safe  conditionals in your configuration management to do be able to test runs without the worry of screwing up e.g. Ansible tasks:
   * Use the **Guard Rail Pattern** by putting safe  conditionals in your configuration management to do be able to test runs without the worry of screwing up e.g. Ansible tasks:
 
-
-```
-- name: “Do something really Dangerous"
-  command: /sbin/something —could —be —dangerous --if --run --it --in --prod
-  when: testmode == “Off"
-```
-
+  ```yaml
+  - name: “Do something really Dangerous"
+    command: /sbin/something —could —be —dangerous --if --run --it --in --prod
+    when: testmode == “Off"
+  ```
 
 ### Processes
 
@@ -162,13 +163,13 @@ It's important to either have or do the following:
     * requires some research,
     * adds value and;
     * is __not__ grunt work e.g. documentation.
-* Assign your new start an [on boarding buddy/mentor](https://hbr.org/2019/06/every-new-employee-needs-an-onboarding-buddy) 
+* Assign your new start an [on boarding buddy/mentor](https://hbr.org/2019/06/every-new-employee-needs-an-onboarding-buddy)
   * Ensure that this "Buddy" has enough free cycles to be there for the new start if needed
 * [Pair](https://www.agilealliance.org/glossary/pairing/) with new start as soon and as often as possible depending on the complexity of the environment this could go on for weeks, don't be afraid to pick up this pairing at a later date if the engineer has never touched that code block before.
 * When [and if] you do a Retro, then base it against a known good baseline i.e.
   * If you are doing production deploys in the early hours of the night and it goes successfully, remember this is not necessarily reflect a **good** deployment.
 * Put as much detail into tasks / stories as possible including:
-  * Assumptions, 
+  * Assumptions,
   * Reference information and existing implementations
   * Ensuring to narrow down the acceptance criteria in order to prevent [unnecessary research or rework](https://idioms.thefreedictionary.com/go+down+the+rabbit+hole)
 * Ideally make your [Tasks/Stories as small as possible](https://www.leadingagile.com/2014/01/small-stories-reduce-variability-velocity-improve-predictability/) this is for a number of reasons some of those being:
@@ -198,7 +199,6 @@ It's important to either have or do the following:
 * If you have adopted a particular [coding style guideline](https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Coding_Style) on your project then document or reference it for new joiners to easily reference and adopt
 * [Story kickoffs](https://elabor8.com.au/how-to-introduce-story-kickoffs-to-your-team/) can be extremely useful to new starters by helping them getting to the mindset of the team, identify areas that aren't immediately visible in the code base and generally reduce constant rework due to poor or missing acceptance criteria.
 
-
 ### Version control management
 
 > “A generation which ignores history has no past and no future.”
@@ -220,7 +220,6 @@ It's important to either have or do the following:
 * Keep your pull request list short and tidy, [merge good requests quickly](https://medium.com/@biratkirat/step-52-let-your-project-speak-for-itself-daniel-lindner-e45a0b1ce2c7) and close poor ones or those that are never going to be merged.
 * Integrate your git history with your external issue tracker so that it can automatically reference the changes related to a story and put in place some [automated branch naming pattern protection](https://help.github.com/en/articles/configuring-protected-branches) to ensure that any branches match the issue trackers issue reference format, this way you enforce the best practice of a branch matching a historical record in (for example) Jira as to why something was created, changed or deleted.
 
-
 ### Development environments
 
 <summary>How do we safely change things</summary>
@@ -241,10 +240,10 @@ It's important to either have or do the following:
   * :+1: Docker containers e.g. [using the Three Musketters pattern](https://3musketeers.io/docs/patterns.html#make)
   * :+1: The ability to create individualized development environments in the cloud e.g. [AWS](https://aws.amazon.com/), [Azure](https://azure.microsoft.com), [Google](https://cloud.google.com/), [Digital Ocean](https://www.digitalocean.com/), etc in order to safely deploy, iterate and test in a separate (and safe) environment
 
-
 ## Useful links
 
 <details>
+
 <summary>Would you like to know more?</summary>
 
 * [Onboarding and Mentoring Apprentices with DevOps Culture](https://vimeo.com/115484860) by [Mercedes Coyle](https://twitter.com/benzobot)


### PR DESCRIPTION
**What** 
This PR replaces the word **engineer** with **practitioner** or replaces **DevOps engineer** with **developer**.

It also makes some grammatical and spelling fixes.

Additionally, it has been run through the excellent [Markdown
Lint](https://github.com/markdownlint/markdownlint) and most straightforward
suggested fixes have been made.

**Why**
I was so very impressed by this piece of writing that I wanted to be associated
with it by being officially on the contributor list! Joking aside, after having
a conversation with @actionjack, I wanted to see if subtle word changes could get
the idea of DevOps being an approach and not a job title to come through more
strongly.


**Summary of commits**
03a33c4 (Ali Asad Lotia, 3 hours ago)
   Make markdownlint happy

   - Added whitespace at the start and end of unordered items
   - Set language definitions on code blocks
   - Fixed indentation inconsistencies

9257ef3 (Ali Asad Lotia, 3 hours ago)
   Wording, spelling and punctuation changes

   - Replace the word `engineer` with practitioner, or developer
   - Add missing full-stops on to some bullet points
   - Fix spelling errors

**How to review this PR**
Since this is largely the work of @actionjack it is entirely his decision to
determine whether the requested changes align with his vision for this doc.

**Who should review this PR**
@actionjack