### PR TITLE
Fix spelling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ It's important to either have or do the following:
 * Make your tooling easy to set up an easy to use cross platform or run a local environment that does not mess up what’s currently there e.g. in a [virtual machine](https://medium.com/@jevgenijdmitrijev/how-to-creating-a-ubuntu-development-environment-with-help-of-virtual-box-f2cc198e1c63)
   * Version managers for example: [asdf](https://github.com/asdf-vm/asdf) [pyenv](https://github.com/pyenv/pyenv), [jenv](http://www.jenv.be/), [Rbenv](https://github.com/rbenv/rbenv), [venv](https://docs.python.org/3/library/venv.html), [virtualenv](https://virtualenv.pypa.io/en/stable/), [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv), [pipenv](https://pipenv.readthedocs.io/en/latest/)
   * :+1: Vagrant boxen in order to test locally
-  * :+1: Docker containers e.g. [using the Three Musketters pattern](https://3musketeers.io/docs/patterns.html#make)
+  * :+1: Docker containers e.g. [using the Three Musketeers pattern](https://3musketeers.io/docs/patterns.html#make)
   * :+1: The ability to create individualized development environments in the cloud e.g. [AWS](https://aws.amazon.com/), [Azure](https://azure.microsoft.com), [Google](https://cloud.google.com/), [Digital Ocean](https://www.digitalocean.com/), etc in order to safely deploy, iterate and test in a separate (and safe) environment
 
 ## Useful links


### PR DESCRIPTION
## What

musketters -> musketeers

## Why

Because spellinng is important.

## How to review

Compare the incorrect spelling `musketters` with the correct spelling
`musketeers` in the [README](README.md) for this fork and master in this repo.
Confirm that master in this repo has the incorrect spelling.

## Who can review

@actionjack